### PR TITLE
Remove non-available builds from filesystem.

### DIFF
--- a/src/Joli/JoliCi/BuildStrategy/TravisCiBuildStrategy.php
+++ b/src/Joli/JoliCi/BuildStrategy/TravisCiBuildStrategy.php
@@ -123,7 +123,8 @@ class TravisCiBuildStrategy implements BuildStrategyInterface
 
                 $builds[] = new Build($buildName, $buildDir);
             } catch (\Twig_Error_Loader $e) {
-                // Do nothing, template does not exist so language-php is not supported by JoliCI (emit a warning ?)
+                // TODO: template does not exist so language-php is not supported by JoliCI (emit a warning ?)
+                $this->filesystem->remove($buildDir);
             }
         }
 


### PR DESCRIPTION
When the language isn't supported by JoliCi, the build directories were
still being left around.  These build directories would then cause
errors when the toplevel directory from the Run command would fail on
rmdir() (RunCommand.php:75).

It still would be better if a warning could be emitted back to the user,
but that would require some extensive changes in order to pass an error
back out of the build strategy class or restructure things so that the
RunCommand can be aware that there were some builds that couldn't be
created.
