### PR TITLE
Add service support to use mysql, mongo, es, ...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ matrix:
     allow_failures:
         - php: hhvm
 
-
 before_script:
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source install
-    
+
 script: phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/finder" : "~2.4",
         "symfony/yaml" : "~2.4",
         "monolog/monolog": "~1.6",
-        "stage1/docker-php": "~0.2.1",
+        "stage1/docker-php": "~0.3.0",
         "cedriclombardot/twig-generator": "~1.0.0",
         "guzzlehttp/streams": "~1.3.0",
         "behat/transliterator": "~1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "37db2becbc494295ec3fea3135c11eab",
+    "hash": "b4c96121d29d806b6c992859a5d3ad14",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -321,16 +321,16 @@
         },
         {
             "name": "stage1/docker-php",
-            "version": "v0.2.3",
+            "version": "v0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stage1/docker-php.git",
-                "reference": "31ff9f4af91dc8eb548a1ab4851d04eee02c61e0"
+                "reference": "73e3245ee6f79fcdd7e77333699975b1c55eee4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stage1/docker-php/zipball/31ff9f4af91dc8eb548a1ab4851d04eee02c61e0",
-                "reference": "31ff9f4af91dc8eb548a1ab4851d04eee02c61e0",
+                "url": "https://api.github.com/repos/stage1/docker-php/zipball/73e3245ee6f79fcdd7e77333699975b1c55eee4a",
+                "reference": "73e3245ee6f79fcdd7e77333699975b1c55eee4a",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +354,7 @@
                 "MIT"
             ],
             "description": "A Docker PHP client",
-            "time": "2014-11-12 17:01:45"
+            "time": "2014-11-19 09:52:33"
         },
         {
             "name": "symfony/console",

--- a/src/Joli/JoliCi/Build.php
+++ b/src/Joli/JoliCi/Build.php
@@ -51,14 +51,20 @@ class Build
     protected $created;
 
     /**
+     * @var Service[] Services linked to this build
+     */
+    private $services = array();
+
+    /**
      * @param string    $project     Project of the build
      * @param string    $strategy    Strategy of the build
      * @param string    $uniq        A uniq identifier for this kind of build
      * @param array     $parameters  Parameters of the build (mainly depend on the strategy)
      * @param string    $description Description of this build (generally a nice name for end user)
      * @param \DateTime $created     Date of creation of the build
+     * @param array $services Services linked to the build
      */
-    public function __construct($project, $strategy, $uniq, $parameters = array(), $description = "", $created = null)
+    public function __construct($project, $strategy, $uniq, $parameters = array(), $description = "", $created = null, $services = array())
     {
         $this->project     = $project;
         $this->description = $description;
@@ -71,6 +77,7 @@ class Build
         }
 
         $this->created = $created;
+        $this->services = $services;
     }
 
     /**
@@ -101,6 +108,26 @@ class Build
     public function getTag()
     {
         return sprintf('%s-%s', $this->uniq, $this->created->format('U'));
+    }
+
+    /**
+     * Add a service to the build
+     *
+     * @param Service $service
+     */
+    public function addService(Service $service)
+    {
+        $this->services[] = $service;
+    }
+
+    /**
+     * Return all services linked to this build
+     *
+     * @return Service[]
+     */
+    public function getServices()
+    {
+        return $this->services;
     }
 
     /**

--- a/src/Joli/JoliCi/Container.php
+++ b/src/Joli/JoliCi/Container.php
@@ -114,10 +114,12 @@ class Container
 
     public function getExecutor($cache = true, $verbose = false, $timeout = 600)
     {
-        //Set timeout in ini (not superb but only way with current docker php library)
-        ini_set('default_socket_timeout', $timeout);
+        return new Executor($this->getLoggerCallback($verbose), $this->getDocker(), $this->getBuildPath(), $cache, false, $timeout);
+    }
 
-        return new Executor($this->getConsoleLogger($verbose), $this->getDocker(), $cache, false);
+    public function getServiceManager($verbose = false)
+    {
+        return new ServiceManager($this->getDocker(), $this->getLoggerCallback($verbose));
     }
 
     public function getBuildPath()
@@ -128,5 +130,10 @@ class Container
     public function getNaming()
     {
         return new Naming();
+    }
+
+    public function getLoggerCallback($verbose)
+    {
+        return new LoggerCallback($this->getConsoleLogger($verbose));
     }
 }

--- a/src/Joli/JoliCi/LoggerCallback.php
+++ b/src/Joli/JoliCi/LoggerCallback.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Joli\JoliCi;
+
+use Psr\Log\LoggerInterface;
+
+class LoggerCallback
+{
+    private $buildCallback;
+
+    private $runCallback;
+
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $build = new \ReflectionMethod($this, 'buildCallback');
+        $run   = new \ReflectionMethod($this, 'runCallback');
+
+        $this->buildCallback = $build->getClosure($this);
+        $this->runCallback   = $run->getClosure($this);
+        $this->logger        = $logger;
+    }
+
+    /**
+     * Get the build log callback when building / pulling an image
+     *
+     * @return callable
+     */
+    public function getBuildCallback()
+    {
+        return $this->buildCallback;
+    }
+
+    /**
+     * Get the run callback for docker
+     *
+     * @return callable
+     */
+    public function getRunCallback()
+    {
+        return $this->runCallback;
+    }
+
+    /**
+     * Clear static log buffer
+     */
+    public function clearStatic()
+    {
+        $this->logger->debug("", array('clear-static' => true));
+    }
+
+    /**
+     * The build callback when creating a image, useful to see what happens during building
+     *
+     * @param string $output An encoded json string from docker daemon
+     */
+    private function buildCallback($output)
+    {
+        $message = "";
+
+        if (isset($output['error'])) {
+            $this->logger->error(sprintf("Error when building image: %s", $output['error']), array('static' => false, 'static-id' => null));
+            return;
+        }
+
+        if (isset($output['stream'])) {
+            $message = $output['stream'];
+        }
+
+        if (isset($output['status'])) {
+            $message = $output['status'];
+
+            if (isset($output['progress'])) {
+                $message .= " " . $output['progress'];
+            }
+        }
+
+        $this->logger->debug($message, array(
+            'static' => isset($output['id']),
+            'static-id' => isset($output['id']) ? $output['id'] : null,
+        ));
+    }
+
+    /**
+     * Run callback to catch logs of test running
+     *
+     * @param string $output Output from run
+     * @param int $type Type of output (2 = Error, 1 = Stdin, 0 = Stdout)
+     */
+    private function runCallback($output, $type)
+    {
+        if ($type === 2) {
+            $this->logger->error($output);
+        } else {
+            $this->logger->info($output);
+        }
+    }
+}

--- a/src/Joli/JoliCi/Service.php
+++ b/src/Joli/JoliCi/Service.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Joli\JoliCi;
+
+use Docker\Container as DockerContainer;
+
+/**
+ * A service is just an application or a tool link to a build which helps running tests
+ *
+ * It can be for example a MySQL database which contains the needed fixtures in order
+ * to make functional tests
+ *
+ * Multiple services can be link to a build and they are started before creation of the build.
+ * Once the build is finished, all services linkes are shutdown and reset to initial state for subsequent build
+ */
+class Service
+{
+    /**
+     * @var string Service name (use in link to container)
+     */
+    private $name;
+
+    /**
+     * @var string Repository for this service (from docker hub)
+     */
+    private $repository;
+
+    /**
+     * @var string Tag for this service (generally the version)
+     */
+    private $tag;
+
+    /**
+     * @var array Config when creating a container
+     */
+    private $config;
+
+    /**
+     * @var \Docker\Container Container used for this service
+     */
+    private $container;
+
+    public function __construct($name, $repository, $tag, $config = array())
+    {
+        $this->name       = $name;
+        $this->repository = $repository;
+        $this->tag        = $tag;
+        $this->config     = $config;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRepository()
+    {
+        return $this->repository;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTag()
+    {
+        return $this->tag;
+    }
+
+    /**
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * @return DockerContainer
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * @param DockerContainer $container
+     */
+    public function setContainer(DockerContainer $container)
+    {
+        $this->container = $container;
+    }
+}

--- a/src/Joli/JoliCi/ServiceManager.php
+++ b/src/Joli/JoliCi/ServiceManager.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Joli\JoliCi;
+
+use Docker\Container as DockerContainer;
+use Docker\Docker;
+use Docker\Exception\ImageNotFoundException;
+use Docker\Exception\UnexpectedStatusCodeException;
+use Psr\Log\LoggerInterface;
+
+class ServiceManager
+{
+    private $docker;
+
+    private $logger;
+
+    public function __construct(Docker $docker, LoggerCallback $logger)
+    {
+        $this->docker = $docker;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Start services for a build
+     *
+     * @param Build $build
+     */
+    public function start(Build $build)
+    {
+        foreach ($build->getServices() as $service) {
+            try {
+                $image = $this->docker->getImageManager()->find($service->getRepository(), $service->getTag());
+            } catch (ImageNotFoundException $e) {
+                $image = $this->docker->getImageManager()->pull($service->getRepository(), $service->getTag(), $this->logger->getBuildCallback());
+            }
+
+            $container = new DockerContainer($service->getConfig());
+            $container->setImage($image);
+            $service->setContainer($container);
+
+            $this->docker->getContainerManager()->run($container, null, array(), true);
+        }
+    }
+
+    /**
+     * Stop services for a build and reinit volumes
+     *
+     * @param Build $build
+     * @param int $timeout
+     *
+     * @throws \Docker\Exception\UnexpectedStatusCodeException
+     */
+    public function stop(Build $build, $timeout = 10)
+    {
+        foreach ($build->getServices() as $service) {
+            if ($service->getContainer()) {
+                try {
+                    $this->docker->getContainerManager()->stop($service->getContainer(), $timeout);
+                } catch (UnexpectedStatusCodeException $e) {
+                    if ($e->getCode() != "304") {
+                        throw $e;
+                    }
+                }
+
+                $this->docker->getContainerManager()->remove($service->getContainer(), true);
+            }
+        }
+    }
+}

--- a/src/Joli/JoliCi/Vacuum.php
+++ b/src/Joli/JoliCi/Vacuum.php
@@ -97,7 +97,7 @@ class Vacuum
         }
 
         foreach ($this->docker->getContainerManager()->findAll(array('all' => 1)) as $container) {
-            $id = $container->getImage()->getId();
+            $id = $container->getConfig()['Image'];
 
             foreach ($images as $image) {
                 if ($image->__toString() == $id) {


### PR DESCRIPTION
Add service management for tests : 

Service config part of travis.yml is now correctly handled, for exemple you can have elasticsearch service launch before you test by adding this to your travis.yml file: 

```
services:
  - elasticsearch
```

A elasticsearch service will be launch before each build and available, for the moment host of the service is set in environment variable of this format (docker link format):

[SERVICE]_PORT_[SERVICE PORT]_TCP_ADDR

In travis all services are on localhost, it's up to the user to use the correct url.

One way to do that can be to use this script before test:

```
if [ -z "$ELASTICSEARCH_PORT_9200_TCP_ADDR" ]; then ELASTICSEARCH_HOST=localhost; else ELASTICSEARCH_HOST=$ELASTICSEARCH_PORT_9200_TCP_ADDR; fi; my_test_command
```

And then ELASTICSEARCH_HOST will be correclty set if under travis or jolici
