### PR TITLE
Set default timezone when not set

### DIFF
--- a/bin/jolici
+++ b/bin/jolici
@@ -6,6 +6,10 @@ use Joli\JoliCi\Command\CleanCommand;
 use Symfony\Component\Console\Application;
 use cbednarski\Pharcc\Git;
 
+if (empty(ini_get('date.timezone'))) {
+    date_default_timezone_set('UTC');
+}
+
 if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once(__DIR__ . '/../vendor/autoload.php');
 } elseif (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {


### PR DESCRIPTION
Jolici won't execute on systems that don't have date.timezone set. Clean installation of OS X for example doesn't set it it.