### PR TITLE
Increase unit tests coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,10 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/Joli/JoliCi/JobTest.php
+++ b/tests/Joli/JoliCi/JobTest.php
@@ -31,22 +31,25 @@ class JobTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($descriptionMock, $jobMock->getDescription());
         $this->assertSame($createdMock, $jobMock->getCreated());
         $this->assertSame($servicesMock, $jobMock->getServices());
+
+        return $jobMock;
     }
 
-    public function testAddAndGetServices()
+    /**
+     * @param Job $jobMock
+     * @depends testConstructInitialisesAllTheFields
+     */
+    public function testAddAndGetServices($jobMock)
     {
-        $jobMock =
-            $this->getMockBuilder('Joli\JoliCI\Job')
-                 ->disableOriginalConstructor()
-                 ->setMethods(null)
-                 ->getMock();
-
-        $serviceMock = new Service('test', 'test', 'test');
-
-        $this->assertEmpty($jobMock->getServices());
+        $serviceMock     = new Service('test', 'test', 'test');
+        $currentServices = $jobMock->getServices();
 
         $jobMock->addService($serviceMock);
-        $this->assertEquals(array($serviceMock), $jobMock->getServices());
+
+        $this->assertEquals(
+            array_merge($currentServices, array($serviceMock)),
+            $jobMock->getServices()
+        );
     }
 
     public function testToStringReturnsTheNameOfTheJob()

--- a/tests/Joli/JoliCi/JobTest.php
+++ b/tests/Joli/JoliCi/JobTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Joli\JoliCi;
+
+class JobTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructInitialisesAllTheFields()
+    {
+        $projectMock     = uniqid();
+        $strategyMock    = uniqid();
+        $uniqMock        = uniqid();
+        $parametersMock  = array('test' => uniqid());
+        $descriptionMock = 'test';
+        $createdMock     = new \DateTime();
+        $servicesMock    = array('service' => uniqid());
+
+        $jobMock = new Job(
+            $projectMock,
+            $strategyMock,
+            $uniqMock,
+            $parametersMock,
+            $descriptionMock,
+            $createdMock,
+            $servicesMock
+        );
+
+        $this->assertAttributeSame($projectMock, 'project', $jobMock);
+        $this->assertSame($strategyMock, $jobMock->getStrategy());
+        $this->assertSame($uniqMock, $jobMock->getUniq());
+        $this->assertSame($parametersMock, $jobMock->getParameters());
+        $this->assertSame($descriptionMock, $jobMock->getDescription());
+        $this->assertSame($createdMock, $jobMock->getCreated());
+        $this->assertSame($servicesMock, $jobMock->getServices());
+    }
+
+    public function testAddAndGetServices()
+    {
+        $jobMock =
+            $this->getMockBuilder('Joli\JoliCI\Job')
+                 ->disableOriginalConstructor()
+                 ->setMethods(null)
+                 ->getMock();
+
+        $serviceMock = new Service('test', 'test', 'test');
+
+        $this->assertEmpty($jobMock->getServices());
+
+        $jobMock->addService($serviceMock);
+        $this->assertEquals(array($serviceMock), $jobMock->getServices());
+    }
+
+    public function testToStringReturnsTheNameOfTheJob()
+    {
+        $jobMock = new Job('project', 'strategy', uniqid());
+
+        $this->assertEquals($jobMock->getName(), $jobMock->__toString());
+    }
+}

--- a/tests/Joli/JoliCi/MatrixTest.php
+++ b/tests/Joli/JoliCi/MatrixTest.php
@@ -4,6 +4,22 @@ namespace Joli\JoliCi;
 
 class MatrixTest extends \PHPUnit_Framework_TestCase
 {
+    public function testSetDimensionWillUseDefaultValuesIfEmptyProvided()
+    {
+        $matrixMock = new Matrix();
+
+        $matrixMock->setDimension('test', array());
+
+        $this->assertAttributeContains(array(null), 'dimensions', $matrixMock);
+    }
+
+    public function testComputeWillReturnEmptyIfNoDimensions()
+    {
+        $matrixMock = new Matrix();
+
+        $this->assertEquals(array(), $matrixMock->compute());
+    }
+
     public function testCompute()
     {
         $matrix = new Matrix();

--- a/tests/Joli/JoliCi/ServiceTest.php
+++ b/tests/Joli/JoliCi/ServiceTest.php
@@ -17,19 +17,19 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($repositoryMock, $serviceMock->getRepository());
         $this->assertSame($tagMock, $serviceMock->getTag());
         $this->assertSame($configMock, $serviceMock->getConfig());
+
+        return $serviceMock;
     }
 
-    public function testSetAndGetContainer()
+    /**
+     * @param Service $serviceMock
+     * @depends testConstructInitialisesAllTheFields
+     */
+    public function testSetAndGetContainer($serviceMock)
     {
         $dockerContainerMock =
             $this->getMockBuilder('Docker\Container')
                  ->setMethods(null)
-                 ->getMock();
-
-        $serviceMock =
-            $this->getMockBuilder('Joli\JoliCI\Service')
-                 ->setMethods(null)
-                 ->disableOriginalConstructor()
                  ->getMock();
 
         $serviceMock->setContainer($dockerContainerMock);

--- a/tests/Joli/JoliCi/ServiceTest.php
+++ b/tests/Joli/JoliCi/ServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Joli\JoliCi;
+
+class ServiceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructInitialisesAllTheFields()
+    {
+        $nameMock       = uniqid();
+        $repositoryMock = uniqid();
+        $tagMock        = uniqid();
+        $configMock     = array('test' => uniqid());
+
+        $serviceMock = new Service($nameMock, $repositoryMock, $tagMock, $configMock);
+
+        $this->assertSame($nameMock, $serviceMock->getName());
+        $this->assertSame($repositoryMock, $serviceMock->getRepository());
+        $this->assertSame($tagMock, $serviceMock->getTag());
+        $this->assertSame($configMock, $serviceMock->getConfig());
+    }
+
+    public function testSetAndGetContainer()
+    {
+        $dockerContainerMock =
+            $this->getMockBuilder('Docker\Container')
+                 ->setMethods(null)
+                 ->getMock();
+
+        $serviceMock =
+            $this->getMockBuilder('Joli\JoliCI\Service')
+                 ->setMethods(null)
+                 ->disableOriginalConstructor()
+                 ->getMock();
+
+        $serviceMock->setContainer($dockerContainerMock);
+
+        $this->assertSame($dockerContainerMock, $serviceMock->getContainer());
+    }
+}


### PR DESCRIPTION
This pull requests increases the coverage of the Job, Matrix and Service classes to 100%.

It also adds a filter to the phpunit configuration file to exclude the vendor (or other non-source) folders when generating code coverage reports.