### PR TITLE
Skip encrypted global environment variables

### DIFF
--- a/src/Joli/JoliCi/BuildStrategy/TravisCiBuildStrategy.php
+++ b/src/Joli/JoliCi/BuildStrategy/TravisCiBuildStrategy.php
@@ -290,6 +290,10 @@ class TravisCiBuildStrategy implements BuildStrategyInterface
 
         if (isset($environmentLines['global'])) {
             foreach ($environmentLines['global'] as $environementVariable) {
+                if (is_array($environementVariable) && array_key_exists('secure', $environementVariable)) {
+                    continue;
+                }
+
                 list ($key, $value) = $this->parseEnvironementVariable($environementVariable);
                 $globalEnv = array_merge($globalEnv, array($key => $value));
             }


### PR DESCRIPTION
Secure global env variables should be skipped, since it currently isn't possible to decrypt the values.
Also the `parseEnvironementVariable` function expects a string, but if secure variables is specified, the value is an array, which causes an error.