### PR TITLE
Add support for string versions

### DIFF
--- a/src/Joli/JoliCi/BuildStrategy/TravisCiBuildStrategy.php
+++ b/src/Joli/JoliCi/BuildStrategy/TravisCiBuildStrategy.php
@@ -276,7 +276,7 @@ class TravisCiBuildStrategy implements BuildStrategyInterface
         $environnements   = array();
         $globalEnv        = array();
         $matrixEnv        = $environmentLines;
-        $versions         = isset($config[$versionKey]) ? $config[$versionKey] : $this->defaults[$language]['default_versions'];
+        $versions         = (array) (isset($config[$versionKey]) ? $config[$versionKey] : $this->defaults[$language]['default_versions']);
 
         foreach ($versions as $key => $version) {
             if (!$this->isLanguageVersionSupported($language, $version)) {

--- a/tests/Joli/JoliCi/BuildStrategy/TravisCIBuildStrategyTest.php
+++ b/tests/Joli/JoliCi/BuildStrategy/TravisCIBuildStrategyTest.php
@@ -32,11 +32,11 @@ class TravisCIBuildStrategyTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider createMatrixVersionDataProvider
      */
-    public function testCreateMatrixCanObtainVersionsFromString($version)
+    public function testCreateMatrixCanObtainVersions($versions)
     {
         $testConfig = [
             'language' => 'php',
-            'php'      => $version,
+            'php'      => $versions,
         ];
 
         $createMatrix = function ($config) {
@@ -46,7 +46,7 @@ class TravisCIBuildStrategyTest extends \PHPUnit_Framework_TestCase
 
         $matrix = $createMatrix($testConfig);
 
-        $this->assertAttributeContains([$version], 'dimensions', $matrix);
+        $this->assertAttributeContains((array) $versions, 'dimensions', $matrix);
     }
 
     /**
@@ -59,6 +59,8 @@ class TravisCIBuildStrategyTest extends \PHPUnit_Framework_TestCase
             [5.5],
             // Test with string
             ['5.5'],
+            // Test with list
+            [['5.5', '5.6', '7']]
         ];
     }
 }

--- a/tests/Joli/JoliCi/BuildStrategy/TravisCIBuildStrategyTest.php
+++ b/tests/Joli/JoliCi/BuildStrategy/TravisCIBuildStrategyTest.php
@@ -28,4 +28,37 @@ class TravisCIBuildStrategyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($support);
     }
+
+    /**
+     * @dataProvider createMatrixVersionDataProvider
+     */
+    public function testCreateMatrixCanObtainVersionsFromString($version)
+    {
+        $testConfig = [
+            'language' => 'php',
+            'php'      => $version,
+        ];
+
+        $createMatrix = function ($config) {
+            return $this->createMatrix($config);
+        };
+        $createMatrix = $createMatrix->bindTo($this->strategy, $this->strategy);
+
+        $matrix = $createMatrix($testConfig);
+
+        $this->assertAttributeContains([$version], 'dimensions', $matrix);
+    }
+
+    /**
+     * @return array
+     */
+    public function createMatrixVersionDataProvider()
+    {
+        return [
+            // Test with float
+            [5.5],
+            // Test with string
+            ['5.5'],
+        ];
+    }
 }


### PR DESCRIPTION
Add support for string versions as requested in issue #69.

I have added tests for both cases: string and lists