### PR TITLE
Fix before_install for PHP images

### DIFF
--- a/resources/templates/php/Dockerfile-hhvm.twig
+++ b/resources/templates/php/Dockerfile-hhvm.twig
@@ -11,4 +11,5 @@ ENV TRAVIS_PHP_VERSION hhvm
 
 {% block before_install %}
 RUN echo 'date.timezone={{ timezone }}' | sudo tee -a /etc/hhvm/php.ini
+{{ parent() }}
 {% endblock %}

--- a/resources/templates/php/Dockerfile.twig
+++ b/resources/templates/php/Dockerfile.twig
@@ -6,4 +6,5 @@
 
 {% block before_install %}
 RUN echo 'date.timezone={{ timezone }}' >> /home/.phpenv/versions/`cat /home/.phpenv/version`/etc/php.ini
+{{ parent() }}
 {% endblock %}


### PR DESCRIPTION
PHP images are broken as `before_install` misses `parent()` call